### PR TITLE
add email API endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from flask import Flask, render_template, url_for, request, session, redirect, j
 from flask_cors import CORS
 from flask_pymongo import PyMongo
 from functools import wraps
+from util import *
 import csv
 import datetime
 import jwt
@@ -112,6 +113,15 @@ def upload():
     return jsonify({
         "message": "accepted file"
     })
+
+@app.route("/developerfeedback", methods=['POST'])
+def developer_feedback():
+    email_address = request.get_json(force = True)['email_address']
+    name = request.get_json(force = True)['name']
+    feedback = request.get_json(force = True)['feedback']
+    subject = request.get_json(force = True)['subject']
+
+    return send_feedback_email(email_address, name, feedback, subject)
 
 def save_upload(f):
     mongodb.save_file(f.filename, f, 'data')

--- a/config.py
+++ b/config.py
@@ -4,3 +4,4 @@ class Config(object):
     TOKEN_SECRET_KEY = 'alecisgod'
     MONGO_DBNAME = 'MLAI'
     MONGO_URI = 'mongodb://localhost:27017/MLAI'
+    SENDGRID_API_KEY = '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'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ datetime
 flask_cors
 pandas
 python-csv
+sendgrid

--- a/util.py
+++ b/util.py
@@ -1,0 +1,18 @@
+from config import Config
+from flask import jsonify
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail
+
+def send_feedback_email(email_address, name, feedback, subject):
+    message = Mail(
+        from_email='MLAI@case.edu',
+        to_emails='isw9@case.edu',
+        subject=subject,
+        html_content='{0} - {1} - {2}'.format(feedback, name, email_address))
+    try:
+        sg = SendGridAPIClient(Config.SENDGRID_API_KEY)
+        response = sg.send(message)
+        return jsonify({'feedback': 'submitted successfully'})
+    except Exception as e:
+        print(e)
+        return jsonify({'feedback': 'error'})


### PR DESCRIPTION
Adds API endpoint that allows users to message us. Idk how to do any of the front end stuff in react so all I did was make the API endpoint. 

Sample request 

```
{
	"email_address": "test@gmail.com",
	"name": "isaac", 
	"feedback": "you have an awesome app",
	"subject": "My Experience"
}
```

Also if you run into a SSL error with sendgrid follow the solution posted on [this](https://stackoverflow.com/questions/44649449/brew-installation-of-python-3-6-1-ssl-certificate-verify-failed-certificate/49953648#49953648) stackoverflow post